### PR TITLE
adding deployments

### DIFF
--- a/deployments/manifest.json
+++ b/deployments/manifest.json
@@ -1,0 +1,40 @@
+{
+	"required": [
+		{
+			"name": "double_attribute.tre",
+			"size": 2060,
+			"md5": "af103a574b9cc050b88f8620a08075eb",
+			"url": "https://swg.hellafast.io/Patcher%20Files/double_attribute.tre"
+		},
+		{
+			"name": "smash_01.tre",
+			"size": 17652,
+			"md5": "2f045f638ae72f8c99a02d3d5028419f",
+			"url": "https://swg.hellafast.io/Patcher%20Files/smash_01.tre"
+		},
+		{
+			"name": "smash_02.tre",
+			"size": 424622,
+			"md5": "71ee8a706b20cca1f8a3c6ca2609c539",
+			"url": "https://swg.hellafast.io/Patcher%20Files/smash_02.tre"
+		},
+		{
+			"name": "smash_03.tre",
+			"size": 2576290,
+			"md5": "3e847d0746dc6cdaab72448c579a3ed0",
+			"url": "https://swg.hellafast.io/Patcher%20Files/smash_03.tre"
+		},
+		{
+			"name": "swgemu_live.cfg",
+			"size": 2254,
+			"md5": "4cbba2c6abd9c2e506df9ba511dc2791",
+			"url": "https://swg.hellafast.io/Patcher%20Files/swgemu_live.cfg"
+		},
+		{
+			"name": "smash.cfg",
+			"size": 0,
+			"md5": "d41d8cd98f00b204e9800998ecf8427e",
+			"url": "https://swg.hellafast.io/Patcher%20Files/smash.cfg"
+		}
+	]
+}

--- a/deployments/md5check.py
+++ b/deployments/md5check.py
@@ -1,0 +1,62 @@
+
+import os
+import hashlib
+import json
+
+# Path to the directory to check and the manifest.json file
+directory_to_check = "/path/to/files"  # Modify this path as needed
+manifest_path = "/var/www/swg/Patcher Files/manifest.json"
+
+# Calculate MD5 checksum for a file
+def calculate_md5(file_path):
+    hash_md5 = hashlib.md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+# Get file information including name and checksum
+def get_file_info(directory):
+    file_info_list = []
+    for root, dirs, files in os.walk(directory):
+        for name in files:
+            file_path = os.path.join(root, name)
+            file_info = {
+                'file_name': os.path.relpath(file_path, directory),
+                'checksum': calculate_md5(file_path)
+            }
+            file_info_list.append(file_info)
+    return file_info_list
+
+# Load or initialize the manifest.json file
+if os.path.exists(manifest_path):
+    with open(manifest_path, 'r') as manifest_file:
+        manifest = json.load(manifest_file)
+else:
+    manifest = {}
+
+# Compare and update manifest.json
+def update_manifest(file_info_list):
+    updated = False
+    for file_info in file_info_list:
+        file_name = file_info['file_name']
+        new_checksum = file_info['checksum']
+        
+        # If the file is new or has a different checksum, update the manifest
+        if manifest.get(file_name) != new_checksum:
+            manifest[file_name] = new_checksum
+            updated = True
+            print(f"Updated checksum for: {file_name}")
+
+    # Save changes to the manifest if updates were made
+    if updated:
+        with open(manifest_path, 'w') as manifest_file:
+            json.dump(manifest, manifest_file, indent=4)
+        print("Manifest.json has been updated.")
+    else:
+        print("No changes detected in the files.")
+
+# Main logic
+if __name__ == "__main__":
+    file_info_list = get_file_info(directory_to_check)
+    update_manifest(file_info_list)


### PR DESCRIPTION
Added manifest.json as well as md5check.py. These changes should automatically write new checksums to the manifest.json file when they are detected by md5check.py. We could, and likely should CRON md5check.py so that process happens automagically.